### PR TITLE
dev->main: Add GitLab upgrade tooling

### DIFF
--- a/infrastructure.code-workspace
+++ b/infrastructure.code-workspace
@@ -6,14 +6,15 @@
 	],
 	"settings": {
 		"cSpell.words": [
-			"manylinux",
-			"pycache",
 			"docstrings",
 			"FISMA",
 			"hostedzone",
 			"ISSO",
+			"keepalive",
 			"manylinux",
-			"tfapply"
+			"pycache",
+			"tfapply",
+			"Upgrader"
 		]
 	}
 }

--- a/scripts/gitlab-upgrade/.gitignore
+++ b/scripts/gitlab-upgrade/.gitignore
@@ -1,0 +1,1 @@
+status.json

--- a/scripts/gitlab-upgrade/README.md
+++ b/scripts/gitlab-upgrade/README.md
@@ -1,4 +1,16 @@
-# GitLab Upgrade Script
+# GitLab Upgrade Scripts
+
+Three scripts for upgrading and managing GitLab EE on RHEL-based EC2 instances.
+
+| Script | Purpose |
+|---|---|
+| `setup_and_run.cmd` + `upgrade.py` | Perform a one-step version upgrade |
+| `trouble-shoot.py` | Collect diagnostics when GitLab is unhealthy |
+| `status-gitlab.py` | Check, start, restart, and watch GitLab services |
+
+---
+
+## upgrade.py
 
 Automates one-step-at-a-time GitLab EE upgrades on RHEL-based EC2 instances.
 GitLab requires sequential version stops — this script determines the correct
@@ -135,3 +147,83 @@ over. Choosing not to resume clears the status and starts fresh.
 Each run upgrades exactly **one version stop**. If the upgrade path shows
 multiple stops between current and latest, re-run `setup_and_run.cmd` after
 each successful upgrade until you reach the target version.
+
+---
+
+## trouble-shoot.py
+
+Collects a comprehensive diagnostic snapshot of the GitLab instance and writes
+everything to a timestamped log in `logs\`. Use this when GitLab is unhealthy
+after an upgrade or at any other time.
+
+Log filename format: `logs\trouble-shoot_YYYYMMDD_HHMMSS.log`
+
+### Running
+
+```cmd
+.venv\Scripts\python.exe trouble-shoot.py
+```
+
+Share the log file to diagnose issues. No changes are made to the instance —
+read-only checks only.
+
+### What it collects
+
+| Category | Details |
+|---|---|
+| **AWS** | EC2 instance state, tags, S3 backup age and size |
+| **System** | Disk space, memory, CPU load, top processes, OOM killer events |
+| **GitLab version** | RPM query, version manifest, gitlab-rake |
+| **Services** | Full `gitlab-ctl status` output |
+| **Processes** | Whether puma, sidekiq, nginx, postgres, redis are running |
+| **Ports** | Whether 80/443/8080/8060 are listening |
+| **Health endpoints** | HTTP status from `/-/health`, `/-/readiness`, `/-/liveness` |
+| **Database** | PostgreSQL connection test, pending migration status |
+| **Reconfigure log** | Last 100 lines of reconfigure output |
+| **Log files** | Rails, Puma, Sidekiq, PostgreSQL, Redis, Nginx, syslog |
+| **yum history** | Recent transactions confirming what was installed |
+| **SELinux / firewall** | Enforcing mode, recent denials, firewall rules |
+| **gitlab.rb** | Non-secret config lines |
+
+---
+
+## status-gitlab.py
+
+Checks GitLab service status via SSH and optionally starts, restarts, or
+watches services. Writes output to a timestamped log in `logs\`.
+
+Log filename format: `logs\status-gitlab_YYYYMMDD_HHMMSS.log`
+
+### Running
+
+```cmd
+.venv\Scripts\python.exe status-gitlab.py [options]
+```
+
+### Options
+
+| Option | Description |
+|---|---|
+| *(no args)* | Show service status table |
+| `--start` | Start all `normally up` services that are down |
+| `--restart` | Restart all services |
+| `--reconfigure` | Run `gitlab-ctl reconfigure` (output streamed live) |
+| `--tail` | Tail logs for all services that are currently down |
+| `--tail puma nginx` | Tail logs for specific named services |
+| `--watch` | Poll every 10s until all services are up |
+| `--watch 30` | Poll every 30s |
+| `--service NAME [NAME ...]` | Scope `--start`, `--restart`, or `--tail` to specific services |
+| `--config PATH` | Use an alternate config file (default: `config.json`) |
+
+Options can be combined. For example, to start any down services and then
+keep watching until everything is healthy:
+
+```cmd
+.venv\Scripts\python.exe status-gitlab.py --start --watch
+```
+
+To restart a single service and tail its log:
+
+```cmd
+.venv\Scripts\python.exe status-gitlab.py --restart --tail --service puma
+```

--- a/scripts/gitlab-upgrade/README.md
+++ b/scripts/gitlab-upgrade/README.md
@@ -1,0 +1,137 @@
+# GitLab Upgrade Script
+
+Automates one-step-at-a-time GitLab EE upgrades on RHEL-based EC2 instances.
+GitLab requires sequential version stops — this script determines the correct
+next stop, verifies backups, performs the upgrade via SSH, and validates the
+result.
+
+## Prerequisites
+
+- Python 3.x installed and on `PATH`
+- AWS named profile configured with access to EC2 and S3 (read-only)
+- SSH private key (`.pem`) for the GitLab EC2 instance
+- Network access to the instance IP (VPN or bastion)
+
+## Configuration
+
+Edit `config.json` before running:
+
+```json
+{
+    "ssh_key_path": "%UserProfile%\\.ssh\\your-key.pem",
+    "ssh_user": "ec2-user",
+    "aws_profile": "sdc-prod",
+    "instance_id": "i-xxxxxxxxxxxxxxxxx",
+    "ip_address": "10.x.x.x",
+    "bucket": "prod-dot-sdc-gitlab-backup-xxxxxxxx"
+}
+```
+
+| Field | Description |
+|---|---|
+| `ssh_key_path` | Path to the EC2 SSH private key. Supports `%UserProfile%` expansion. |
+| `ssh_user` | SSH username on the EC2 instance (typically `ec2-user`). |
+| `aws_profile` | AWS named profile to use for EC2/S3 API calls. |
+| `instance_id` | EC2 instance ID of the GitLab server. |
+| `ip_address` | Private IP address of the GitLab EC2 instance. |
+| `bucket` | S3 bucket name where GitLab backups are stored. |
+
+## How to Run
+
+From the `scripts\gitlab-upgrade\` directory:
+
+```cmd
+setup_and_run.cmd
+```
+
+That's it. The script handles venv creation, dependency installation, and
+launches `upgrade.py` automatically.
+
+### What `setup_and_run.cmd` does
+
+1. Creates a Python virtual environment (`.venv\`) if one does not exist
+2. Activates the venv and upgrades `pip`
+3. Installs dependencies from `requirements.txt`
+4. Runs `upgrade.py`
+5. Deactivates the venv on exit
+
+## What the Upgrade Script Does
+
+The script walks through six stages, prompting for confirmation at key
+decision points.
+
+### Stage 1 — Instance Check
+
+Calls the EC2 API using the configured `aws_profile` to verify the GitLab
+instance is in a `running` state. Aborts if the instance is stopped or
+unavailable.
+
+### Stage 2 — Backup Verification
+
+Lists objects in the configured S3 bucket and finds the most recent:
+
+- `*_gitlab_backup.tar` — full GitLab data backup
+- `*gitlab-secrets.json` — GitLab secrets/tokens
+
+Displays each file's name, size, and last-modified timestamp. If the backup
+tar is older than 24 hours, you are asked whether to abort and create a
+manual backup first. You must confirm before proceeding.
+
+### Stage 3 — Get Current Version
+
+SSH into the instance and runs several commands to detect the installed
+GitLab EE version (e.g., `18.3.1`).
+
+### Stage 4 — Determine Upgrade Path
+
+Fetches GitLab's official upgrade path data and identifies all version stops
+between the current version and the latest release. Displays the full path
+and selects the **next required stop** as the upgrade target. GitLab does
+not support skipping stops.
+
+### Stage 5 — Perform Upgrade
+
+Asks for a final confirmation, then runs three commands on the instance over
+SSH:
+
+1. `yum update -y --exclude=gitlab-ee` — patches system packages without
+   pulling the latest GitLab
+2. `yum install -y gitlab-ee-{target_version}` — installs the specific
+   target version
+3. `gitlab-ctl reconfigure` — applies configuration and database migrations
+   (takes 5–10 minutes)
+
+Output is streamed in real time so you can monitor progress.
+
+### Stage 6 — Post-Upgrade Validation
+
+Runs `gitlab-ctl status` over SSH and checks that all services are up.
+Prints a reminder to manually verify the web UI:
+
+1. Log in to an SDC workstation
+2. Navigate to `https://gitlab.prod.sdc.dot.gov/`
+3. Confirm the UI loads and the version in **Admin > Overview** matches
+   the target
+
+## Logs
+
+Each run writes a log to `logs\` in this directory, named:
+
+```text
+logs\{from_version}_to_{to_version}_{timestamp}.log
+```
+
+Example: `logs\18.3.1_to_18.4.0_20260401_143000.log`
+
+## Resume Capability
+
+If the script is interrupted (network drop, Ctrl+C, etc.), a `status.json`
+file records the last completed step. On the next run, the script detects
+this file and offers to resume from where it left off rather than starting
+over. Choosing not to resume clears the status and starts fresh.
+
+## Running Successive Upgrades
+
+Each run upgrades exactly **one version stop**. If the upgrade path shows
+multiple stops between current and latest, re-run `setup_and_run.cmd` after
+each successful upgrade until you reach the target version.

--- a/scripts/gitlab-upgrade/config.json
+++ b/scripts/gitlab-upgrade/config.json
@@ -1,0 +1,8 @@
+{
+    "ssh_key_path": "%UserProfile%\\.ssh\\ost-sdc-prod.pem",
+    "ssh_user": "ec2-user",
+    "aws_profile": "sdc-prod",
+    "instance_id": "i-05d528e00209fe1f7",
+    "ip_address": "10.75.210.236",
+    "bucket": "prod-dot-sdc-gitlab-backup-004118380849"
+}

--- a/scripts/gitlab-upgrade/requirements.txt
+++ b/scripts/gitlab-upgrade/requirements.txt
@@ -1,0 +1,4 @@
+boto3~=1.42
+paramiko~=4.0
+requests~=2.32
+packaging~=21.0

--- a/scripts/gitlab-upgrade/setup_and_run.cmd
+++ b/scripts/gitlab-upgrade/setup_and_run.cmd
@@ -1,0 +1,81 @@
+@echo off
+setlocal enabledelayedexpansion
+
+echo ============================================================
+echo GitLab Upgrade - Environment Setup
+echo ============================================================
+echo.
+
+REM Check if venv exists
+if not exist ".venv\" (
+    echo Creating virtual environment...
+    python -m venv .venv
+    if errorlevel 1 (
+        echo ERROR: Failed to create virtual environment
+        exit /b 1
+    )
+    echo Virtual environment created successfully
+    echo.
+) else (
+    echo Virtual environment already exists
+    echo.
+)
+
+REM Activate venv
+echo Activating virtual environment...
+call .venv\Scripts\activate.bat
+if errorlevel 1 (
+    echo ERROR: Failed to activate virtual environment
+    exit /b 1
+)
+echo.
+
+REM Upgrade pip
+echo Upgrading pip...
+python -m pip install --upgrade pip --quiet
+if errorlevel 1 (
+    echo WARNING: Failed to upgrade pip
+) else (
+    echo pip upgraded successfully
+)
+echo.
+
+REM Install/upgrade requirements
+if exist "requirements.txt" (
+    echo Installing requirements...
+    pip install -r requirements.txt --quiet
+    if errorlevel 1 (
+        echo ERROR: Failed to install requirements
+        echo.
+        echo Troubleshooting:
+        echo   1. Check requirements.txt format
+        echo   2. Try manually: .venv\Scripts\python.exe -m pip install -r requirements.txt
+        echo   3. Check network connectivity / proxy settings
+        exit /b 1
+    )
+    echo Requirements installed successfully
+    echo.
+) else (
+    echo WARNING: requirements.txt not found
+    echo Expected: boto3~=1.42, paramiko~=4.0, requests~=2.32
+    echo.
+    set /p continue="Continue anyway? (y/n): "
+    if /i not "!continue!"=="y" (
+        echo Aborted by user
+        exit /b 1
+    )
+)
+
+REM Run the upgrade script
+echo ============================================================
+echo Starting GitLab Upgrade Script
+echo ============================================================
+echo.
+
+python upgrade.py
+set EXIT_CODE=%errorlevel%
+
+REM Deactivate venv
+call .venv\Scripts\deactivate.bat 2>nul
+
+exit /b %EXIT_CODE%

--- a/scripts/gitlab-upgrade/status-gitlab.py
+++ b/scripts/gitlab-upgrade/status-gitlab.py
@@ -1,0 +1,558 @@
+#!/usr/bin/env python3
+"""
+GitLab service status checker and manager.
+
+Connects to the GitLab EC2 instance via SSH and reports service status.
+Optionally starts stopped services, restarts all services, or runs reconfigure.
+
+Usage:
+    python status-gitlab.py                          # status only
+    python status-gitlab.py --start                  # start any 'normally up' services that are down
+    python status-gitlab.py --restart                # restart all services
+    python status-gitlab.py --restart --service puma nginx   # restart specific services
+    python status-gitlab.py --reconfigure            # run gitlab-ctl reconfigure
+    python status-gitlab.py --watch                  # re-check every 10s until all services are up
+    python status-gitlab.py --watch 30               # re-check every 30s
+    python status-gitlab.py --tail puma              # tail logs for one or more services
+    python status-gitlab.py --start --tail           # start downed services then tail their logs
+"""
+
+import argparse
+import json
+import logging
+import os
+import re
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import paramiko
+
+
+# ---------------------------------------------------------------------------
+# Logging — console + logs/status-gitlab_YYYYMMDD_HHMMSS.log
+# ---------------------------------------------------------------------------
+import datetime as _dt
+_logs_dir = Path("logs")
+_logs_dir.mkdir(exist_ok=True)
+LOG_PATH = _logs_dir / f"status-gitlab_{_dt.datetime.now().strftime('%Y%m%d_%H%M%S')}.log"
+
+_log_level = getattr(logging, os.environ.get("LOG_LEVEL", "INFO").upper(), logging.INFO)
+logger = logging.getLogger()
+logger.setLevel(_log_level)
+for _h in logger.handlers[:]:
+    logger.removeHandler(_h)
+
+_ch = logging.StreamHandler()
+_ch.setLevel(_log_level)
+_ch.setFormatter(logging.Formatter("%(levelname)s - %(message)s"))
+logger.addHandler(_ch)
+
+_fh = logging.FileHandler(LOG_PATH, mode="a", encoding="utf-8")
+_fh.setLevel(_log_level)
+_fh.setFormatter(logging.Formatter("%(message)s"))
+logger.addHandler(_fh)
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ServiceInfo:
+    """Represents one GitLab runit service."""
+
+    name: str
+    state: str           # "run" | "down" | "unknown"
+    pid: Optional[int]
+    uptime_s: Optional[int]
+    normally_up: bool    # True if runit says "normally up"
+    raw: str             # original status line
+
+    @property
+    def is_up(self) -> bool:
+        """Return True if the service is running."""
+        return self.state == "run"
+
+    @property
+    def uptime_human(self) -> str:
+        """Return uptime as a human-readable string."""
+        if self.uptime_s is None:
+            return "?"
+        h, remainder = divmod(self.uptime_s, 3600)
+        m, s = divmod(remainder, 60)
+        if h:
+            return f"{h}h {m}m {s}s"
+        if m:
+            return f"{m}m {s}s"
+        return f"{s}s"
+
+
+# ---------------------------------------------------------------------------
+# Parser for `gitlab-ctl status` output
+# ---------------------------------------------------------------------------
+
+_STATUS_RE = re.compile(
+    r"^(?P<state>run|down):\s+(?P<name>[\w-]+):\s+"
+    r"(?:\(pid\s+(?P<pid>\d+)\)\s+)?(?P<uptime>\d+)s"
+    r"(?P<normally>,\s*normally up)?"
+)
+
+
+def parse_status(output: str) -> List[ServiceInfo]:
+    """
+    Parse output of ``gitlab-ctl status`` into a list of ServiceInfo objects.
+
+    Args:
+        output: Raw stdout from ``gitlab-ctl status``.
+
+    Returns:
+        List of parsed ServiceInfo objects, sorted by name.
+    """
+    services: List[ServiceInfo] = []
+    for line in output.splitlines():
+        line = line.strip()
+        m = _STATUS_RE.match(line)
+        if not m:
+            continue
+        services.append(ServiceInfo(
+            name=m.group("name"),
+            state=m.group("state"),
+            pid=int(m.group("pid")) if m.group("pid") else None,
+            uptime_s=int(m.group("uptime")),
+            normally_up=bool(m.group("normally")),
+            raw=line,
+        ))
+    return sorted(services, key=lambda s: s.name)
+
+
+# ---------------------------------------------------------------------------
+# Main class
+# ---------------------------------------------------------------------------
+
+class GitLabServiceManager:
+    """SSH-based GitLab service status checker and manager."""
+
+    def __init__(self, config_path: str = "config.json") -> None:
+        """
+        Initialize with config.json.
+
+        Args:
+            config_path: Path to JSON config containing instance details.
+
+        Raises:
+            ValueError: If a required config key is missing.
+            FileNotFoundError: If config_path does not exist.
+        """
+        with open(config_path, "r") as f:
+            config: Dict = json.load(f)
+        config["ssh_key_path"] = os.path.expandvars(config["ssh_key_path"])
+        for key in ["instance_id", "ip_address", "ssh_key_path", "ssh_user"]:
+            if key not in config:
+                raise ValueError(f"Missing required config key: {key}")
+        self.config = config
+        self.ssh_client: Optional[paramiko.SSHClient] = None
+
+    # ------------------------------------------------------------------
+    # SSH helpers
+    # ------------------------------------------------------------------
+
+    def connect(self, retries: int = 3) -> bool:
+        """
+        Establish SSH connection with retry logic.
+
+        Args:
+            retries: Number of attempts before giving up.
+
+        Returns:
+            True if connected, False otherwise.
+        """
+        for attempt in range(retries):
+            try:
+                if self.ssh_client:
+                    self.ssh_client.close()
+                self.ssh_client = paramiko.SSHClient()
+                self.ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+                self.ssh_client.connect(
+                    hostname=self.config["ip_address"],
+                    username=self.config["ssh_user"],
+                    key_filename=self.config["ssh_key_path"],
+                    timeout=30,
+                    banner_timeout=30,
+                )
+                transport = self.ssh_client.get_transport()
+                if transport:
+                    transport.set_keepalive(30)
+                return True
+            except Exception as e:  # noqa: BLE001
+                logger.warning("SSH attempt %d/%d failed: %s", attempt + 1, retries, e)
+                if attempt < retries - 1:
+                    time.sleep(3)
+        logger.error("Could not establish SSH connection to %s", self.config["ip_address"])
+        return False
+
+    def _run(self, command: str, timeout: int = 120, stream: bool = False) -> Tuple[int, str, str]:
+        """
+        Execute a command over SSH.
+
+        Args:
+            command: Shell command to run.
+            timeout: Seconds before timing out.
+            stream:  If True, print stdout lines in real time via logger.
+
+        Returns:
+            Tuple of (exit_code, stdout, stderr).
+        """
+        assert self.ssh_client is not None, "Call connect() first"
+
+        transport = self.ssh_client.get_transport()
+        if not transport or not transport.is_active():
+            if not self.connect():
+                return (1, "", "SSH disconnected and reconnect failed")
+
+        try:
+            _, stdout, stderr = self.ssh_client.exec_command(command, timeout=timeout)
+
+            if stream:
+                stdout_lines: List[str] = []
+                while not stdout.channel.exit_status_ready():
+                    if stdout.channel.recv_ready():
+                        chunk = stdout.channel.recv(4096).decode("utf-8", errors="replace")
+                        for line in chunk.splitlines():
+                            logger.info("  %s", line)
+                            stdout_lines.append(line)
+                    time.sleep(0.1)
+                remainder = stdout.read().decode("utf-8", errors="replace")
+                for line in remainder.splitlines():
+                    logger.info("  %s", line)
+                    stdout_lines.append(line)
+                exit_code = stdout.channel.recv_exit_status()
+                return (exit_code, "\n".join(stdout_lines), stderr.read().decode("utf-8", errors="replace"))
+
+            out = stdout.read().decode("utf-8", errors="replace")
+            err = stderr.read().decode("utf-8", errors="replace")
+            return (stdout.channel.recv_exit_status(), out, err)
+
+        except Exception as e:  # noqa: BLE001
+            return (1, "", str(e))
+
+    def disconnect(self) -> None:
+        """Close the SSH connection."""
+        if self.ssh_client:
+            self.ssh_client.close()
+
+    # ------------------------------------------------------------------
+    # Service operations
+    # ------------------------------------------------------------------
+
+    def get_status(self) -> List[ServiceInfo]:
+        """
+        Fetch and parse current GitLab service status.
+
+        Returns:
+            Parsed list of ServiceInfo objects, sorted by name.
+        """
+        _, out, _ = self._run("sudo gitlab-ctl status", timeout=30)
+        return parse_status(out)
+
+    def print_status_table(self, services: List[ServiceInfo]) -> None:
+        """
+        Print a formatted status table.
+
+        Args:
+            services: List of ServiceInfo to display.
+        """
+        up   = [s for s in services if s.is_up]
+        down = [s for s in services if not s.is_up]
+
+        logger.info("")
+        logger.info("  %-22s  %-6s  %-12s  %s", "SERVICE", "STATE", "UPTIME", "PID")
+        logger.info("  " + "-" * 58)
+        for s in up:
+            logger.info("  %-22s  %-6s  %-12s  %s", s.name, "UP", s.uptime_human, s.pid or "")
+        for s in down:
+            flag = "  (normally up)" if s.normally_up else ""
+            logger.info("  %-22s  %-6s  %-12s%s", s.name, "DOWN", s.uptime_human, flag)
+        logger.info("")
+        logger.info("  Summary: %d up, %d down", len(up), len(down))
+
+    def start_services(self, services: List[ServiceInfo], targets: Optional[List[str]] = None) -> List[str]:
+        """
+        Start services that are down.
+
+        If targets is None, starts all services marked "normally up" that are down.
+        If targets is provided, starts only those named services regardless of
+        their normally_up flag.
+
+        Args:
+            services: Current service list from get_status().
+            targets:  Optional explicit list of service names to start.
+
+        Returns:
+            Names of services that were successfully started.
+        """
+        if targets:
+            to_start = [s for s in services if not s.is_up and s.name in targets]
+        else:
+            to_start = [s for s in services if not s.is_up and s.normally_up]
+
+        if not to_start:
+            logger.info("  No services need starting.")
+            return []
+
+        started: List[str] = []
+        for s in to_start:
+            logger.info("  Starting %-20s ...", s.name)
+            rc, out, err = self._run(f"sudo gitlab-ctl start {s.name}", timeout=60)
+            if rc == 0:
+                logger.info("    OK")
+                started.append(s.name)
+            else:
+                logger.warning("    FAILED (rc=%d)  %s", rc, (err or out).strip())
+        return started
+
+    def restart_services(self, services: List[ServiceInfo], targets: Optional[List[str]] = None) -> None:
+        """
+        Restart services.
+
+        Args:
+            services: Current service list from get_status().
+            targets:  If provided, only restart these named services.
+                      If None, restarts all services.
+        """
+        to_restart = [s for s in services if targets is None or s.name in targets]
+        if not to_restart:
+            logger.info("  No matching services found.")
+            return
+
+        for s in to_restart:
+            logger.info("  Restarting %-20s ...", s.name)
+            rc, _, err = self._run(f"sudo gitlab-ctl restart {s.name}", timeout=60)
+            if rc == 0:
+                logger.info("    OK")
+            else:
+                logger.warning("    FAILED (rc=%d)  %s", rc, err.strip())
+
+    def reconfigure(self) -> bool:
+        """
+        Run ``gitlab-ctl reconfigure``, streaming output in real time.
+
+        Returns:
+            True if reconfigure exited 0, False otherwise.
+        """
+        logger.info("")
+        logger.info("  Running gitlab-ctl reconfigure (5-10 minutes)...")
+        logger.info("")
+        rc, _, _ = self._run("sudo gitlab-ctl reconfigure", timeout=900, stream=True)
+        logger.info("")
+        if rc != 0:
+            logger.warning("  reconfigure exited with code %d", rc)
+            return False
+        logger.info("  reconfigure completed successfully")
+        return True
+
+    def tail_services(self, names: List[str], lines: int = 60) -> None:
+        """
+        Tail recent log lines for each named service.
+
+        Args:
+            names: Service names to tail.
+            lines: Number of tail lines per service.
+        """
+        for name in names:
+            logger.info("")
+            logger.info("  --- %s (last %d lines) ---", name, lines)
+            _, out, _ = self._run(
+                f"sudo tail -{lines} /var/log/gitlab/{name}/current 2>/dev/null || "
+                f"sudo tail -{lines} /var/log/gitlab/{name}/{name}_stderr.log 2>/dev/null || "
+                f"echo '(no log found at /var/log/gitlab/{name}/)'",
+                timeout=30,
+            )
+            for line in out.splitlines():
+                logger.info("    %s", line)
+
+    def watch(self, interval: int, targets: Optional[List[str]] = None) -> None:
+        """
+        Poll service status repeatedly until all expected services are up.
+
+        Stops automatically when no "normally up" services are down, or on
+        Ctrl+C.
+
+        Args:
+            interval: Seconds between polls.
+            targets:  If set, only watch these named services.
+        """
+        import datetime
+        poll = 0
+        while True:
+            poll += 1
+            ts = datetime.datetime.now().strftime("%H:%M:%S")
+            logger.info("")
+            logger.info("  [%s]  poll #%d", ts, poll)
+            services = self.get_status()
+            if targets:
+                services = [s for s in services if s.name in targets]
+            self.print_status_table(services)
+
+            down_normally_up = [s for s in services if not s.is_up and s.normally_up]
+            if not down_normally_up:
+                logger.info("  All expected services are up.")
+                break
+
+            logger.info("  Still down: %s — rechecking in %ds...",
+                        ", ".join(s.name for s in down_normally_up), interval)
+            time.sleep(interval)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the argument parser."""
+    p = argparse.ArgumentParser(
+        description="Check and manage GitLab services via SSH.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    p.add_argument(
+        "--start",
+        action="store_true",
+        help="Start any 'normally up' services that are currently down.",
+    )
+    p.add_argument(
+        "--restart",
+        action="store_true",
+        help="Restart services (all services, or those named with --service).",
+    )
+    p.add_argument(
+        "--reconfigure",
+        action="store_true",
+        help="Run sudo gitlab-ctl reconfigure (streams output in real time).",
+    )
+    p.add_argument(
+        "--tail",
+        nargs="*",
+        metavar="SERVICE",
+        help=(
+            "Tail service logs. With no service names, tails all services that "
+            "are down. Pass service names to tail specific ones (e.g. --tail puma nginx)."
+        ),
+    )
+    p.add_argument(
+        "--service",
+        nargs="+",
+        metavar="NAME",
+        help="Scope --start / --restart / --tail to specific service(s).",
+    )
+    p.add_argument(
+        "--watch",
+        nargs="?",
+        const=10,
+        type=int,
+        metavar="SECONDS",
+        help=(
+            "Poll status repeatedly until all services are up. "
+            "Optional interval in seconds (default: 10)."
+        ),
+    )
+    p.add_argument(
+        "--config",
+        default="config.json",
+        metavar="PATH",
+        help="Path to config.json (default: config.json).",
+    )
+    return p
+
+
+def section(title: str) -> None:
+    """Print a clearly delimited section header."""
+    logger.info("")
+    logger.info("=" * 60)
+    logger.info("  %s", title)
+    logger.info("=" * 60)
+
+
+def main() -> None:
+    """Entry point."""
+    import datetime
+    args = build_parser().parse_args()
+
+    logger.info("=" * 60)
+    logger.info("  GitLab Service Manager")
+    logger.info("  %s", datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
+    logger.info("=" * 60)
+
+    mgr = GitLabServiceManager(config_path=args.config)
+    logger.info("  Connecting to %s ...", mgr.config["ip_address"])
+    if not mgr.connect():
+        sys.exit(1)
+    logger.info("  Connected")
+
+    try:
+        # --reconfigure runs first — it will start all services itself
+        if args.reconfigure:
+            section("Reconfigure")
+            mgr.reconfigure()
+
+        # Always show status
+        section("Service Status")
+        services = mgr.get_status()
+        mgr.print_status_table(services)
+
+        # --start
+        if args.start:
+            section("Starting Down Services")
+            started = mgr.start_services(services, targets=args.service)
+            if started:
+                logger.info("  Started: %s", ", ".join(started))
+                time.sleep(2)
+                section("Service Status (after start)")
+                services = mgr.get_status()
+                mgr.print_status_table(services)
+
+        # --restart
+        if args.restart:
+            section("Restarting Services")
+            mgr.restart_services(services, targets=args.service)
+            time.sleep(2)
+            section("Service Status (after restart)")
+            services = mgr.get_status()
+            mgr.print_status_table(services)
+
+        # --tail
+        if args.tail is not None:
+            section("Service Logs")
+            if args.tail:
+                # Explicit service names on the flag itself
+                tail_targets = args.tail
+            elif args.service:
+                # Fall back to --service names
+                tail_targets = args.service
+            else:
+                # Default: tail all services that are currently down
+                tail_targets = [s.name for s in services if not s.is_up]
+
+            if tail_targets:
+                mgr.tail_services(tail_targets)
+            else:
+                logger.info("  All services are up — nothing to tail.")
+
+        # --watch (runs last so it reflects any start/restart actions above)
+        if args.watch is not None:
+            section(f"Watching (interval: {args.watch}s)")
+            mgr.watch(interval=args.watch, targets=args.service)
+
+    except KeyboardInterrupt:
+        logger.info("\n  Interrupted by user")
+    finally:
+        mgr.disconnect()
+
+    logger.info("")
+    logger.info("  Log written to: %s", LOG_PATH)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gitlab-upgrade/trouble-shoot.py
+++ b/scripts/gitlab-upgrade/trouble-shoot.py
@@ -1,0 +1,549 @@
+#!/usr/bin/env python3
+"""
+GitLab post-upgrade troubleshooting script.
+
+Connects to the GitLab EC2 instance via SSH and AWS APIs to collect
+diagnostic information. All output is written to trouble-shoot.log
+for review and analysis.
+"""
+
+import json
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import boto3
+import paramiko
+from botocore.exceptions import ClientError
+
+
+# ---------------------------------------------------------------------------
+# Logging — write to both console and logs/trouble-shoot_YYYYMMDD_HHMMSS.log
+# ---------------------------------------------------------------------------
+_logs_dir = Path("logs")
+_logs_dir.mkdir(exist_ok=True)
+LOG_PATH = _logs_dir / f"trouble-shoot_{datetime.now().strftime('%Y%m%d_%H%M%S')}.log"
+
+_log_level = getattr(logging, os.environ.get("LOG_LEVEL", "INFO").upper(), logging.INFO)
+logger = logging.getLogger()
+logger.setLevel(_log_level)
+for _h in logger.handlers[:]:
+    logger.removeHandler(_h)
+
+_ch = logging.StreamHandler()
+_ch.setLevel(_log_level)
+_ch.setFormatter(logging.Formatter("%(levelname)s - %(message)s"))
+logger.addHandler(_ch)
+
+_fh = logging.FileHandler(LOG_PATH, mode="a", encoding="utf-8")
+_fh.setLevel(_log_level)
+_fh.setFormatter(logging.Formatter("%(message)s"))
+logger.addHandler(_fh)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def section(title: str) -> None:
+    """Write a clearly delimited section header to the log."""
+    bar = "=" * 72
+    logger.info("")
+    logger.info(bar)
+    logger.info("  %s", title)
+    logger.info(bar)
+
+
+def subsection(title: str) -> None:
+    """Write a subsection header."""
+    logger.info("")
+    logger.info("--- %s ---", title)
+
+
+def log_result(label: str, value: str) -> None:
+    """Write a labelled key/value result."""
+    logger.info("  %-30s %s", label + ":", value)
+
+
+def log_block(content: str, indent: int = 2) -> None:
+    """Write a multi-line block with indentation, skipping blank lines at edges."""
+    prefix = " " * indent
+    lines = content.rstrip().splitlines()
+    for line in lines:
+        logger.info("%s%s", prefix, line)
+
+
+# ---------------------------------------------------------------------------
+# Main troubleshooter
+# ---------------------------------------------------------------------------
+
+class GitLabTroubleshooter:
+    """Collects diagnostic data from a GitLab EC2 instance after a failed upgrade."""
+
+    # Log files to tail — (label, remote path, lines)
+    LOG_FILES: List[Tuple[str, str, int]] = [
+        ("Reconfigure",        "/var/log/gitlab/reconfigure.log",                    80),
+        ("Rails Production",   "/var/log/gitlab/gitlab-rails/production.log",        60),
+        ("Rails Exceptions",   "/var/log/gitlab/gitlab-rails/exceptions_json.log",   30),
+        ("Puma STDERR",        "/var/log/gitlab/puma/puma_stderr.log",               60),
+        ("Puma Current",       "/var/log/gitlab/puma/current",                       60),
+        ("Sidekiq Current",    "/var/log/gitlab/sidekiq/current",                    40),
+        ("PostgreSQL Current", "/var/log/gitlab/postgresql/current",                 40),
+        ("Redis Current",      "/var/log/gitlab/redis/current",                      30),
+        ("Nginx Error",        "/var/log/gitlab/nginx/error.log",                    40),
+        ("Nginx GitLab Error", "/var/log/gitlab/nginx/gitlab_error.log",             40),
+        ("System Messages",    "/var/log/messages",                                  40),
+    ]
+
+    def __init__(self, config_path: str = "config.json") -> None:
+        """
+        Initialize the troubleshooter.
+
+        Args:
+            config_path: Path to config.json containing instance details.
+        """
+        self.config = self._load_config(config_path)
+        os.environ["AWS_PROFILE"] = self.config["aws_profile"]
+
+        self.ssh_client: Optional[paramiko.SSHClient] = None
+        self.ec2: Any = boto3.client("ec2", region_name="us-east-1")
+        self.s3: Any = boto3.client("s3", region_name="us-east-1")
+
+    # ------------------------------------------------------------------
+    # Config / SSH
+    # ------------------------------------------------------------------
+
+    def _load_config(self, config_path: str) -> Dict:
+        """
+        Load and validate configuration from JSON.
+
+        Args:
+            config_path: Path to the config file.
+
+        Returns:
+            Parsed configuration dict with expanded paths.
+
+        Raises:
+            ValueError: If a required key is missing.
+        """
+        with open(config_path, "r") as f:
+            config = json.load(f)
+        config["ssh_key_path"] = os.path.expandvars(config["ssh_key_path"])
+        for key in ["instance_id", "ip_address", "ssh_key_path", "ssh_user", "aws_profile"]:
+            if key not in config:
+                raise ValueError(f"Missing required config key: {key}")
+        return config
+
+    def _connect_ssh(self, retries: int = 3) -> bool:
+        """
+        Establish (or re-establish) an SSH connection to the instance.
+
+        Args:
+            retries: Number of connection attempts before giving up.
+
+        Returns:
+            True if connection succeeded, False otherwise.
+        """
+        for attempt in range(retries):
+            try:
+                if self.ssh_client:
+                    self.ssh_client.close()
+                self.ssh_client = paramiko.SSHClient()
+                self.ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+                logger.info("  Connecting to %s (attempt %d/%d)...",
+                            self.config["ip_address"], attempt + 1, retries)
+                self.ssh_client.connect(
+                    hostname=self.config["ip_address"],
+                    username=self.config["ssh_user"],
+                    key_filename=self.config["ssh_key_path"],
+                    timeout=30,
+                    banner_timeout=30,
+                )
+                transport = self.ssh_client.get_transport()
+                if transport:
+                    transport.set_keepalive(30)
+                logger.info("  SSH connection established")
+                return True
+            except Exception as e:  # noqa: BLE001
+                logger.warning("  SSH attempt %d failed: %s", attempt + 1, e)
+        logger.error("  ERROR: Could not establish SSH connection after %d attempts", retries)
+        return False
+
+    def _ssh(self, command: str, timeout: int = 120) -> Tuple[int, str, str]:
+        """
+        Run a command on the remote instance.
+
+        Args:
+            command: Shell command to execute.
+            timeout: Seconds to wait for the command to finish.
+
+        Returns:
+            Tuple of (exit_code, stdout, stderr).
+        """
+        if not self.ssh_client:
+            if not self._connect_ssh():
+                return (1, "", "No SSH connection")
+        assert self.ssh_client is not None
+
+        transport = self.ssh_client.get_transport()
+        if not transport or not transport.is_active():
+            if not self._connect_ssh():
+                return (1, "", "No SSH connection")
+        assert self.ssh_client is not None
+
+        try:
+            _, stdout, stderr = self.ssh_client.exec_command(command, timeout=timeout)
+            stdout_str = stdout.read().decode("utf-8", errors="replace")
+            stderr_str = stderr.read().decode("utf-8", errors="replace")
+            exit_code = stdout.channel.recv_exit_status()
+            return (exit_code, stdout_str, stderr_str)
+        except Exception as e:  # noqa: BLE001
+            return (1, "", str(e))
+
+    # ------------------------------------------------------------------
+    # AWS checks
+    # ------------------------------------------------------------------
+
+    def check_instance_state(self) -> None:
+        """Check EC2 instance state and basic metadata via the AWS API."""
+        section("AWS — EC2 Instance State")
+        try:
+            resp = self.ec2.describe_instances(InstanceIds=[self.config["instance_id"]])
+            inst = resp["Reservations"][0]["Instances"][0]
+            log_result("Instance ID",    inst.get("InstanceId", "unknown"))
+            log_result("State",          inst["State"]["Name"])
+            log_result("Instance Type",  inst.get("InstanceType", "unknown"))
+            log_result("Launch Time",    str(inst.get("LaunchTime", "unknown")))
+            log_result("Private IP",     inst.get("PrivateIpAddress", "unknown"))
+            log_result("Image ID",       inst.get("ImageId", "unknown"))
+
+            tags = {t["Key"]: t["Value"] for t in inst.get("Tags", [])}
+            if tags:
+                subsection("Tags")
+                for k, v in tags.items():
+                    log_result(k, v)
+
+        except ClientError as e:
+            logger.error("  ERROR: %s", e)
+
+    def check_s3_backups(self) -> None:
+        """List the most recent GitLab backups in S3."""
+        section("AWS — S3 Backup Status")
+        bucket = self.config.get("bucket", "")
+        if not bucket:
+            logger.warning("  No bucket configured — skipping backup check")
+            return
+
+        try:
+            resp = self.s3.list_objects_v2(Bucket=bucket)
+            if "Contents" not in resp:
+                logger.warning("  No objects found in bucket: %s", bucket)
+                return
+
+            backup_tar = None
+            secrets_json = None
+            for obj in resp["Contents"]:
+                key = obj.get("Key", "")
+                lm = obj.get("LastModified")
+                if key.endswith("_gitlab_backup.tar"):
+                    if not backup_tar or (lm and backup_tar.get("LastModified") and lm > backup_tar["LastModified"]):
+                        backup_tar = obj
+                elif key.endswith("gitlab-secrets.json"):
+                    if not secrets_json or (lm and secrets_json.get("LastModified") and lm > secrets_json["LastModified"]):
+                        secrets_json = obj
+
+            now = datetime.now(timezone.utc)
+
+            for label, obj in [("Backup TAR", backup_tar), ("Secrets JSON", secrets_json)]:
+                if obj:
+                    age = now - obj["LastModified"] if obj.get("LastModified") else None
+                    age_str = f"{age.days}d {age.seconds // 3600}h ago" if age else "unknown"
+                    log_result(f"{label} key",  obj.get("Key", "unknown"))
+                    log_result(f"{label} age",  age_str)
+                    log_result(f"{label} size", f"{obj.get('Size', 0) / (1024**3):.2f} GB")
+                else:
+                    logger.warning("  %s: NOT FOUND", label)
+
+        except ClientError as e:
+            logger.error("  ERROR: %s", e)
+
+    # ------------------------------------------------------------------
+    # System checks (via SSH)
+    # ------------------------------------------------------------------
+
+    def check_system_resources(self) -> None:
+        """Check disk space, memory, CPU load, and uptime."""
+        section("System Resources")
+
+        checks: List[Tuple[str, str]] = [
+            ("Uptime / Load",  "uptime"),
+            ("Disk Space",     "df -h --output=source,size,used,avail,pcent,target | grep -v tmpfs"),
+            ("Memory",         "free -h"),
+            ("CPU Count",      "nproc"),
+            ("Top Processes",  "ps aux --sort=-%cpu | head -20"),
+            ("OOM Killer Log", "sudo dmesg -T | grep -i 'oom\\|killed process' | tail -20"),
+        ]
+
+        for label, cmd in checks:
+            subsection(label)
+            rc, out, err = self._ssh(cmd)
+            if out.strip():
+                log_block(out)
+            if err.strip() and rc != 0:
+                logger.warning("  STDERR: %s", err.strip())
+
+    def check_gitlab_version(self) -> None:
+        """Detect what GitLab version is currently installed."""
+        section("GitLab — Installed Version")
+
+        cmds: List[Tuple[str, str]] = [
+            ("RPM query",           "rpm -qa gitlab-ee"),
+            ("Version manifest",    "sudo cat /opt/gitlab/version-manifest.txt | head -5"),
+            ("gitlab-rake env",     "sudo gitlab-rake gitlab:env:info 2>&1 | grep -E 'GitLab|version'"),
+        ]
+
+        for label, cmd in cmds:
+            subsection(label)
+            rc, out, err = self._ssh(cmd, timeout=60)
+            if out.strip():
+                log_block(out)
+            elif rc != 0:
+                logger.info("  (no output — rc=%d)", rc)
+
+    def check_gitlab_services(self) -> None:
+        """Run gitlab-ctl status to see which services are up or down."""
+        section("GitLab — Service Status (gitlab-ctl status)")
+        rc, out, err = self._ssh("sudo gitlab-ctl status", timeout=60)
+        if out.strip():
+            log_block(out)
+        if err.strip():
+            log_block(err)
+        if rc != 0:
+            logger.warning("  WARNING: gitlab-ctl status exited with code %d", rc)
+
+    def check_process_list(self) -> None:
+        """Check whether key GitLab processes are running."""
+        section("GitLab — Process Presence")
+
+        processes: List[str] = ["puma", "sidekiq", "nginx", "postgres", "redis"]
+        for proc in processes:
+            _, out, _ = self._ssh(f"pgrep -a {proc} 2>/dev/null | head -5")
+            if out.strip():
+                log_result(proc, "RUNNING")
+                log_block(out, indent=4)
+            else:
+                log_result(proc, "NOT FOUND")
+
+    def check_network_ports(self) -> None:
+        """Verify that GitLab is listening on expected ports (80, 443, 8080)."""
+        section("Network — Listening Ports")
+        _, out, _ = self._ssh("sudo ss -tlnp | grep -E ':(80|443|8080|8060)\\b'")
+        if out.strip():
+            log_block(out)
+        else:
+            logger.warning("  No GitLab ports (80/443/8080/8060) appear to be listening")
+
+        # Also show full listening list for context
+        subsection("All Listening TCP Ports")
+        _, out, _ = self._ssh("sudo ss -tlnp")
+        if out.strip():
+            log_block(out)
+
+    def check_health_endpoints(self) -> None:
+        """Curl the GitLab health check endpoints from localhost on the instance."""
+        section("GitLab — Health Endpoint Checks (from localhost)")
+
+        endpoints: List[Tuple[str, str]] = [
+            ("/-/health",       "curl -sf --max-time 10 -o /dev/null -w '%{http_code}' http://localhost/-/health"),
+            ("/-/readiness",    "curl -sf --max-time 10 -o /dev/null -w '%{http_code}' http://localhost/-/readiness"),
+            ("/-/liveness",     "curl -sf --max-time 10 -o /dev/null -w '%{http_code}' http://localhost/-/liveness"),
+        ]
+
+        for label, cmd in endpoints:
+            rc, out, err = self._ssh(cmd, timeout=30)
+            status = out.strip() if out.strip() else "(no response)"
+            result = f"HTTP {status}" if status.isdigit() else status
+            if rc != 0 and not out.strip():
+                result = f"UNREACHABLE (rc={rc})"
+            log_result(label, result)
+
+        # Full JSON response from readiness for detail
+        subsection("Readiness Detail (JSON)")
+        _, out, _ = self._ssh(
+            "curl -sf --max-time 10 http://localhost/-/readiness 2>&1 | python3 -m json.tool 2>/dev/null || "
+            "curl -sf --max-time 10 http://localhost/-/readiness 2>&1",
+            timeout=30,
+        )
+        if out.strip():
+            log_block(out)
+        else:
+            logger.info("  (no response)")
+
+    def check_database(self) -> None:
+        """Check PostgreSQL service and pending migrations."""
+        section("Database — PostgreSQL & Migrations")
+
+        subsection("PostgreSQL Process")
+        _, out, _ = self._ssh("sudo gitlab-ctl status postgresql 2>&1")
+        log_block(out or "(no output)")
+
+        subsection("Can Connect to DB")
+        _, out, _ = self._ssh(
+            "sudo gitlab-psql -c 'SELECT version();' 2>&1 | head -5",
+            timeout=30,
+        )
+        log_block(out or "(no output)")
+
+        subsection("Pending Migrations (last 30 lines)")
+        logger.info("  Running db:migrate:status — this may take 30-60 seconds...")
+        _, out, err = self._ssh(
+            "sudo gitlab-rake db:migrate:status 2>&1 | tail -30",
+            timeout=120,
+        )
+        log_block(out or "(no output)")
+        if err.strip():
+            log_block(err)
+
+    def check_reconfigure_log(self) -> None:
+        """Show the tail of the most recent reconfigure run."""
+        section("GitLab — Last Reconfigure Output")
+        rc, out, _ = self._ssh(
+            "sudo tail -100 /var/log/gitlab/reconfigure.log 2>/dev/null || "
+            "sudo journalctl -u gitlab-runsvdir --no-pager -n 100 2>/dev/null",
+            timeout=30,
+        )
+        if out.strip():
+            log_block(out)
+        else:
+            logger.info("  No reconfigure log found")
+
+    def check_log_files(self) -> None:
+        """Tail key GitLab and system log files for recent errors."""
+        section("Log Files — Recent Entries")
+        for label, path, lines in self.LOG_FILES:
+            subsection(f"{label}  ({path})")
+            rc, out, err = self._ssh(
+                f"sudo tail -{lines} {path} 2>/dev/null",
+                timeout=30,
+            )
+            if out.strip():
+                log_block(out)
+            else:
+                logger.info("  (file not found or empty)")
+
+    def check_yum_history(self) -> None:
+        """Show recent yum transactions so we can confirm what was installed."""
+        section("Package Manager — Recent yum Transactions")
+
+        subsection("Last 5 Transactions")
+        _, out, _ = self._ssh("sudo yum history list last 5 2>&1", timeout=30)
+        log_block(out or "(no output)")
+
+        subsection("Last Transaction Info (gitlab-ee)")
+        _, out, _ = self._ssh(
+            "sudo yum history info last 2>&1 | grep -E 'gitlab|Install|Update|Error' | head -30",
+            timeout=30,
+        )
+        log_block(out or "(no output)")
+
+    def check_selinux_and_firewall(self) -> None:
+        """Check SELinux status and firewall rules that might block GitLab."""
+        section("SELinux & Firewall")
+
+        subsection("SELinux Status")
+        _, out, _ = self._ssh("getenforce 2>/dev/null || sestatus 2>/dev/null || echo 'SELinux tools not found'")
+        log_block(out or "(no output)")
+
+        subsection("Recent SELinux Denials (last 20)")
+        _, out, _ = self._ssh("sudo ausearch -m avc -ts recent 2>&1 | tail -20")
+        log_block(out or "(no output — may mean no denials or auditd not running)")
+
+        subsection("Firewall Rules (firewalld)")
+        _, out, _ = self._ssh("sudo firewall-cmd --list-all 2>/dev/null || sudo iptables -L -n 2>/dev/null | head -40")
+        log_block(out or "(no output)")
+
+    def check_gitlab_config(self) -> None:
+        """Show non-secret relevant lines from gitlab.rb."""
+        section("GitLab — Configuration Snapshot (gitlab.rb, non-secret lines)")
+        _, out, _ = self._ssh(
+            "sudo grep -v -E \"#|password|secret|token|private_key|^$\" "
+            "/etc/gitlab/gitlab.rb 2>/dev/null | head -60",
+            timeout=30,
+        )
+        log_block(out or "(no output or file not found)")
+
+    # ------------------------------------------------------------------
+    # Orchestration
+    # ------------------------------------------------------------------
+
+    def run(self) -> int:
+        """
+        Run all diagnostic checks and write results to trouble-shoot.log.
+
+        Returns:
+            0 on completion (partial failures are logged, not fatal).
+        """
+        start = datetime.now()
+
+        logger.info("=" * 72)
+        logger.info("  GitLab Troubleshooter")
+        logger.info("  Started: %s", start.strftime("%Y-%m-%d %H:%M:%S"))
+        logger.info("  Instance: %s  (%s)", self.config["instance_id"], self.config["ip_address"])
+        logger.info("  AWS Profile: %s", self.config["aws_profile"])
+        logger.info("  Log: %s", LOG_PATH)
+        logger.info("=" * 72)
+
+        try:
+            # AWS-level (no SSH needed)
+            self.check_instance_state()
+            self.check_s3_backups()
+
+            # All remaining checks need SSH
+            if not self._connect_ssh():
+                logger.error("")
+                logger.error("FATAL: Cannot SSH to instance — AWS and backup checks logged above.")
+                logger.error("Verify the instance is running, your VPN/network is up, and the key path is correct.")
+                return 1
+
+            self.check_system_resources()
+            self.check_gitlab_version()
+            self.check_gitlab_services()
+            self.check_process_list()
+            self.check_network_ports()
+            self.check_health_endpoints()
+            self.check_database()
+            self.check_reconfigure_log()
+            self.check_log_files()
+            self.check_yum_history()
+            self.check_selinux_and_firewall()
+            self.check_gitlab_config()
+
+        except KeyboardInterrupt:
+            logger.info("\nInterrupted by user")
+        except Exception as e:  # noqa: BLE001
+            import traceback
+            logger.error("FATAL: %s\n%s", e, traceback.format_exc())
+        finally:
+            if self.ssh_client:
+                self.ssh_client.close()
+
+        elapsed = datetime.now() - start
+        section("Done")
+        logger.info("  Elapsed: %s", elapsed)
+        logger.info("  Output written to: %s", LOG_PATH)
+        logger.info("")
+
+        return 0
+
+
+def main() -> None:
+    """Entry point."""
+    upgrader = GitLabTroubleshooter()
+    sys.exit(upgrader.run())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gitlab-upgrade/upgrade.py
+++ b/scripts/gitlab-upgrade/upgrade.py
@@ -1,0 +1,660 @@
+#!/usr/bin/env python3
+"""
+GitLab upgrade orchestrator for RHEL-based EC2 instances.
+
+Handles automated upgrade path calculation, backup verification,
+SSH-based upgrade execution with resilience, and post-upgrade validation.
+"""
+
+import json
+import sys
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Dict, Optional, Tuple, Any
+import time
+
+import boto3
+import paramiko
+import requests
+from botocore.exceptions import ClientError
+
+
+class GitLabUpgrader:
+    """Orchestrates GitLab version upgrades with safety checks and logging."""
+
+    def __init__(self, config_path: str = "config.json"):
+        """
+        Initialize upgrader with configuration.
+
+        Args:
+            config_path: Path to JSON config file containing instance details
+        """
+        self.config = self._load_config(config_path)
+        
+        # Set AWS profile BEFORE creating clients
+        os.environ['AWS_PROFILE'] = self.config['aws_profile']
+        
+        self.log_file: Optional[Path] = None
+        self.ssh_client: Optional[paramiko.SSHClient] = None
+        self.status_file = Path("status.json")
+        self.status: Dict = self._load_status()
+        
+        # AWS clients - now they'll use the correct profile
+        self.ec2: Any = boto3.client('ec2', region_name='us-east-1')
+        self.s3: Any = boto3.client('s3', region_name='us-east-1')
+        
+    def _load_config(self, config_path: str) -> Dict:
+        """Load and validate configuration file."""
+        with open(config_path, 'r') as f:
+            config = json.load(f)
+        
+        # Expand Windows environment variables in paths
+        config['ssh_key_path'] = os.path.expandvars(config['ssh_key_path'])
+        
+        required_keys = ['instance_id', 'ip_address', 'ssh_key_path', 'ssh_user', 'aws_profile']
+        for key in required_keys:
+            if key not in config:
+                raise ValueError(f"Missing required config key: {key}")
+        
+        return config
+    
+    def _load_status(self) -> Dict:
+        """Load or initialize status tracking file."""
+        if self.status_file.exists():
+            with open(self.status_file, 'r') as f:
+                return json.load(f)
+        return {"current_step": "init", "last_success": None}
+    
+    def _save_status(self, step: str):
+        """Save current step to status file."""
+        self.status["current_step"] = step
+        self.status["last_success"] = step
+        self.status["timestamp"] = datetime.now(timezone.utc).isoformat()
+        with open(self.status_file, 'w') as f:
+            json.dump(self.status, f, indent=2)
+        self._log(f"✓ Saved status: {step}")
+    
+    def _reset_status(self):
+        """Clear status file after successful completion."""
+        if self.status_file.exists():
+            self.status_file.unlink()
+        self._log("✓ Reset status file")
+    
+    def _log(self, message: str):
+        """Write message to console and log file."""
+        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        log_entry = f"[{timestamp}] {message}"
+        print(log_entry)
+        
+        if self.log_file:
+            with open(self.log_file, 'a', encoding='utf-8') as f:
+                f.write(log_entry + "\n")
+    
+    def _confirm(self, prompt: str) -> bool:
+        """Prompt user for yes/no confirmation."""
+        self._log(prompt)  # Log the prompt with timestamp
+        while True:
+            response = input(f"{" "*21} (y/n): ").strip().lower()
+            if response in ['y', 'yes']:
+                self._log(f"User response: yes")
+                return True
+            elif response in ['n', 'no']:
+                self._log(f"User response: no")
+                return False
+            print("Please enter 'y' or 'n'")
+    
+    def check_instance_state(self) -> bool:
+        """Verify EC2 instance is running."""
+        self._log(f"Checking instance state: {self.config['instance_id']}")
+        
+        try:
+            response = self.ec2.describe_instances(
+                InstanceIds=[self.config['instance_id']]
+            )
+            state = response['Reservations'][0]['Instances'][0]['State']['Name']
+            
+            self._log(f"Instance state: {state}")
+            
+            if state != 'running':
+                self._log(f"ERROR: Instance must be running (current: {state})")
+                return False
+            
+            self._save_status("instance_checked")
+            return True
+            
+        except ClientError as e:
+            self._log(f"ERROR: Failed to check instance: {e}")
+            return False
+    
+    def check_backups(self) -> bool:
+        """
+        Verify recent backups exist in S3.
+        
+        Returns:
+            True if backups are acceptable, False otherwise
+        """
+        self._log("Checking S3 backups...")
+        bucket = "prod-dot-sdc-gitlab-backup-004118380849"
+        
+        try:
+            # List all objects
+            response = self.s3.list_objects_v2(Bucket=bucket)
+            
+            if 'Contents' not in response:
+                self._log("ERROR: No backups found in S3 bucket")
+                return False
+            
+            # Find latest backup files
+            backup_tar = None
+            secrets_json = None
+            
+            for obj in response['Contents']:
+                key = obj.get('Key', '')
+                last_modified = obj.get('LastModified')
+                
+                if key.endswith('_gitlab_backup.tar'):
+                    if not backup_tar or (last_modified and backup_tar.get('LastModified') and last_modified > backup_tar['LastModified']):
+                        backup_tar = obj
+                elif key.endswith('gitlab-secrets.json'):
+                    if not secrets_json or (last_modified and secrets_json.get('LastModified') and last_modified > secrets_json['LastModified']):
+                        secrets_json = obj
+            
+            if not backup_tar or not secrets_json:
+                self._log("ERROR: Missing backup files (need both .tar and secrets.json)")
+                return False
+            
+            # Display backup info
+            self._log("" + "="*60)
+            self._log("LATEST BACKUPS:")
+            self._log(f"  Backup TAR:    {backup_tar.get('Key', 'unknown')}")
+            self._log(f"    Last Modified: {backup_tar.get('LastModified', 'unknown')}")
+            self._log(f"    Size: {backup_tar.get('Size', 0) / (1024**3):.2f} GB")
+            self._log("")
+            self._log(f"  Secrets JSON:  {secrets_json.get('Key', 'unknown')}")
+            self._log(f"    Last Modified: {secrets_json.get('LastModified', 'unknown')}")
+            self._log("="*60)
+            
+            # Check backup age
+            now = datetime.now(timezone.utc)
+            backup_last_modified = backup_tar.get('LastModified')
+            
+            if backup_last_modified:
+                backup_age = now - backup_last_modified
+                
+                if backup_age > timedelta(hours=24):
+                    self._log(f"⚠ WARNING: Backup is {backup_age.days} days old (expected < 24hrs)")
+                    
+                    if self._confirm("Create manual backup before proceeding?"):
+                        self._log("Please run manual backup:")
+                        self._log("  SSH to instance and run: sudo gitlab-backup create")
+                        self._log("  Then re-run this script")
+                        return False
+                    
+                    if not self._confirm("Proceed with old backup anyway?"):
+                        self._log("Upgrade aborted by user")
+                        return False
+            
+            if not self._confirm("Backups verified. Proceed with upgrade?"):
+                self._log("Upgrade aborted by user")
+                return False
+            
+            self._save_status("backups_checked")
+            return True
+            
+        except ClientError as e:
+            self._log(f"ERROR: Failed to check S3 backups: {e}")
+            return False
+    
+    def _connect_ssh(self, retries: int = 3) -> bool:
+        """
+        Establish SSH connection with retry logic.
+        
+        Args:
+            retries: Number of connection attempts
+            
+        Returns:
+            True if connected, False otherwise
+        """
+        for attempt in range(retries):
+            try:
+                if self.ssh_client:
+                    self.ssh_client.close()
+                
+                self.ssh_client = paramiko.SSHClient()
+                self.ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+                
+                self._log(f"Connecting to {self.config['ip_address']} (attempt {attempt + 1}/{retries})")
+                
+                self.ssh_client.connect(
+                    hostname=self.config['ip_address'],
+                    username=self.config['ssh_user'],
+                    key_filename=self.config['ssh_key_path'],
+                    timeout=30,
+                    banner_timeout=30
+                )
+                
+                # Enable keepalive
+                transport = self.ssh_client.get_transport()
+                if transport:
+                    transport.set_keepalive(30)
+                
+                self._log("✓ SSH connection established")
+                return True
+                
+            except Exception as e:
+                self._log(f"SSH connection failed: {e}")
+                if attempt < retries - 1:
+                    time.sleep(5)
+        
+        return False
+    
+    def _run_ssh_command(self, command: str, timeout: int = 3600, stream: bool = False) -> Tuple[int, str, str]:
+        """
+        Execute command via SSH with retry logic.
+        
+        Args:
+            command: Command to execute
+            timeout: Command timeout in seconds
+            stream: Whether to stream output in real-time
+            
+        Returns:
+            Tuple of (exit_code, stdout, stderr)
+        """
+        # Ensure we have a valid SSH connection
+        if not self.ssh_client:
+            if not self._connect_ssh():
+                return (1, "", "Failed to establish SSH connection")
+        
+        # After connection attempt, ssh_client should be set
+        assert self.ssh_client is not None, "SSH client should be initialized"
+        
+        transport = self.ssh_client.get_transport()
+        if not transport or not transport.is_active():
+            if not self._connect_ssh():
+                return (1, "", "Failed to establish SSH connection")
+        
+        # Re-assert after potential reconnection
+        assert self.ssh_client is not None, "SSH client should be initialized after reconnection"
+        
+        try:
+            self._log(f"Executing: {command}")
+            stdin, stdout, stderr = self.ssh_client.exec_command(command, timeout=timeout)
+            
+            if stream:
+                # Stream output in real-time
+                stdout_lines = []
+                stderr_lines = []
+                
+                while not stdout.channel.exit_status_ready():
+                    if stdout.channel.recv_ready():
+                        line = stdout.channel.recv(1024).decode('utf-8')
+                        print(line, end='')
+                        stdout_lines.append(line)
+                    
+                    if stderr.channel.recv_stderr_ready():
+                        line = stderr.channel.recv_stderr(1024).decode('utf-8')
+                        print(line, end='', file=sys.stderr)
+                        stderr_lines.append(line)
+                    
+                    time.sleep(0.1)
+                
+                # Get remaining output
+                stdout_lines.append(stdout.read().decode('utf-8'))
+                stderr_lines.append(stderr.read().decode('utf-8'))
+                
+                exit_code = stdout.channel.recv_exit_status()
+                return (exit_code, ''.join(stdout_lines), ''.join(stderr_lines))
+            else:
+                stdout_str = stdout.read().decode('utf-8')
+                stderr_str = stderr.read().decode('utf-8')
+                exit_code = stdout.channel.recv_exit_status()
+                
+                return (exit_code, stdout_str, stderr_str)
+                
+        except Exception as e:
+            self._log(f"Command execution failed: {e}")
+            return (1, "", str(e))
+    
+    def get_current_version(self) -> Optional[str]:
+        """
+        Retrieve current GitLab version from instance.
+        
+        Returns:
+            Version string (e.g., "18.3.1") or None if failed
+        """
+        self._log("Retrieving current GitLab version...")
+        
+        if not self._connect_ssh():
+            return None
+        
+        # Try multiple methods to get version
+        commands = [
+            "sudo gitlab-rake gitlab:env:info | grep 'GitLab information'",
+            "sudo cat /opt/gitlab/version-manifest.txt | head -1",
+            "rpm -qa gitlab-ee | head -1"
+        ]
+        
+        for cmd in commands:
+            exit_code, stdout, stderr = self._run_ssh_command(cmd)
+            
+            if exit_code == 0 and stdout:
+                # Parse version from output
+                # Format examples:
+                # "GitLab information => 18.3.1-ee"
+                # "gitlab-ee 18.3.1"
+                # "gitlab-ee-18.3.1-ee.0.el8.x86_64"
+                
+                import re
+                version_match = re.search(r'(\d+\.\d+\.\d+)', stdout)
+                if version_match:
+                    version = version_match.group(1)
+                    self._log(f"✓ Current version: {version}")
+                    self._save_status("version_retrieved")
+                    return version
+        
+        self._log("ERROR: Could not determine GitLab version")
+        return None
+    
+    def get_upgrade_path(self, current_version: str) -> Optional[Dict]:
+        """
+        Query GitLab upgrade path API for next step.
+        
+        Args:
+            current_version: Current GitLab version (e.g., "18.3.1")
+            
+        Returns:
+            Dict with upgrade path info or None if failed
+        """
+        self._log(f"Querying upgrade path API for version {current_version}...")
+        
+        try:
+            # The API returns supported and all versions
+            url = "https://gitlab-com.gitlab.io/support/toolbox/upgrade-path/path.json"
+            
+            response = requests.get(url, timeout=30)
+            response.raise_for_status()
+            
+            data = response.json()
+            
+            # Get list of all versions (these are the required stops)
+            all_versions = data.get('all', [])
+            
+            if not all_versions:
+                self._log("ERROR: No versions found in upgrade path API")
+                return None
+            
+            # Parse current version
+            from packaging import version
+            current_ver = version.parse(current_version)
+            
+            # Find all versions greater than current
+            future_versions = []
+            for ver_str in all_versions:
+                ver = version.parse(ver_str)
+                if ver > current_ver:
+                    future_versions.append(ver_str)
+            
+            if not future_versions:
+                self._log(f"✓ Already at latest version: {current_version}")
+                return None
+            
+            # Sort versions
+            future_versions.sort(key=version.parse)
+            
+            # Display upgrade path
+            self._log("" + "="*60)
+            self._log("UPGRADE PATH:")
+            self._log(f"  Current: {current_version}")
+            
+            for ver in future_versions:
+                self._log(f"  → {ver}")
+            
+            # Next version is the first in the future list
+            next_version = future_versions[0]
+            
+            self._log(f"Next upgrade target: {next_version}")
+            self._log("="*60)
+            
+            upgrade_info = {
+                'current_version': current_version,
+                'next_version': next_version,
+                'upgrade_path': future_versions
+            }
+            
+            self._save_status("upgrade_path_retrieved")
+            return upgrade_info
+            
+        except Exception as e:
+            self._log(f"ERROR: Failed to get upgrade path: {e}")
+            import traceback
+            self._log(traceback.format_exc())
+            return None
+    
+    def perform_upgrade(self, target_version: str) -> bool:
+        """
+        Execute the GitLab package upgrade.
+        
+        Args:
+            target_version: Target GitLab version to upgrade to
+            
+        Returns:
+            True if upgrade succeeded, False otherwise
+        """
+        self._log(f"Starting upgrade to version {target_version}...")
+        
+        if not self._confirm(f"Proceed with upgrade to {target_version}?"):
+            self._log("Upgrade aborted by user")
+            return False
+        
+        # Ensure SSH connection
+        if not self._connect_ssh():
+            return False
+        
+        # Step 1: Update package cache (excluding gitlab-ee to prevent yum from
+        # jumping to the latest available version instead of the pinned target)
+        self._log("[1/3] Updating system packages (excluding gitlab-ee)...")
+        self._save_status("upgrade_yum_update")
+
+        exit_code, stdout, stderr = self._run_ssh_command(
+            "sudo yum update -y --exclude=gitlab-ee",
+            timeout=600,
+            stream=True
+        )
+
+        if exit_code != 0:
+            self._log(f"ERROR: yum update failed (exit {exit_code})")
+            self._log(f"STDERR: {stderr}")
+            return False
+        
+        # Step 2: Install target GitLab version
+        self._log(f"[2/3] Installing gitlab-ee-{target_version}...")
+        self._save_status(f"upgrade_install_{target_version}")
+        
+        exit_code, stdout, stderr = self._run_ssh_command(
+            f"sudo yum install -y gitlab-ee-{target_version}",
+            timeout=3600,
+            stream=True
+        )
+        
+        if exit_code != 0:
+            self._log(f"ERROR: GitLab installation failed (exit {exit_code})")
+            self._log(f"STDERR: {stderr}")
+            
+            # Try to determine state
+            self._log("Attempting to determine upgrade state...")
+            new_version = self.get_current_version()
+            if new_version == target_version:
+                self._log(f"✓ Version check shows {target_version} - upgrade may have succeeded despite error")
+            else:
+                return False
+        
+        # Step 3: Reconfigure GitLab
+        self._log("[3/3] Reconfiguring GitLab (this may take 5-10 minutes)...")
+        self._save_status("upgrade_reconfigure")
+        
+        exit_code, stdout, stderr = self._run_ssh_command(
+            "sudo gitlab-ctl reconfigure",
+            timeout=1200,
+            stream=True
+        )
+        
+        if exit_code != 0:
+            self._log(f"WARNING: gitlab-ctl reconfigure returned exit code {exit_code}")
+            self._log(f"STDERR: {stderr}")
+        
+        self._save_status("upgrade_complete")
+        return True
+    
+    def verify_upgrade(self) -> bool:
+        """
+        Run post-upgrade validation checks.
+        
+        Returns:
+            True if validation passed, False otherwise
+        """
+        self._log("" + "="*60)
+        self._log("POST-UPGRADE VALIDATION")
+        self._log("="*60)
+        
+        # Check new version
+        new_version = self.get_current_version()
+        if not new_version:
+            self._log("ERROR: Could not verify new version")
+            return False
+        
+        # Check service status
+        self._log("Checking GitLab services...")
+        exit_code, stdout, stderr = self._run_ssh_command(
+            "sudo gitlab-ctl status",
+            timeout=60
+        )
+        
+        if exit_code != 0:
+            self._log(f"ERROR: gitlab-ctl status failed (exit {exit_code})")
+            self._log(f"OUTPUT:\n{stdout}")
+            return False
+        
+        self._log("GitLab services status:")
+        self._log(stdout)
+        
+        # Check for any down services
+        if 'down:' in stdout.lower():
+            self._log("⚠ WARNING: Some services appear to be down")
+            return False
+        
+        self._log("✓ All services running")
+        
+        # Remind about web UI check
+        self._log("" + "="*60)
+        self._log("MANUAL VERIFICATION REQUIRED:")
+        self._log("  1. Login to an SDC workstation")
+        self._log("  2. Navigate to: https://gitlab.prod.sdc.dot.gov/")
+        self._log("  3. Verify the web UI loads correctly")
+        self._log("  4. Check the version in Admin > Overview")
+        self._log("="*60)
+        
+        self._save_status("validation_complete")
+        return True
+    
+    def cleanup(self):
+        """Close connections and cleanup resources."""
+        if self.ssh_client:
+            self.ssh_client.close()
+            self._log("✓ Closed SSH connection")
+    
+    def run(self) -> int:
+        """Execute the full upgrade workflow."""
+        try:
+            # Initialize logging
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            self.log_file = Path("logs") / f"upgrade_{timestamp}.log"
+            self.log_file.parent.mkdir(exist_ok=True)
+            
+            self._log("="*60)
+            self._log("GitLab Upgrade Script - Starting")
+            self._log("="*60)
+            
+            # Resume from last successful step if status file exists
+            if self.status["last_success"]:
+                self._log(f"Resuming from last successful step: {self.status['last_success']}")
+                if not self._confirm("Continue from previous run?"):
+                    self._reset_status()
+            
+            # Step 1: Check instance state
+            if self.status["last_success"] in [None, "init"]:
+                if not self.check_instance_state():
+                    return 1
+            
+            # Step 2: Verify backups
+            if self.status["last_success"] in [None, "init", "instance_checked"]:
+                if not self.check_backups():
+                    return 1
+            
+            # Step 3: Get current version
+            current_version = self.get_current_version()
+            if not current_version:
+                return 1
+            
+            # Step 4: Get upgrade path
+            upgrade_data = self.get_upgrade_path(current_version)
+            if not upgrade_data or 'next_version' not in upgrade_data:
+                self._log("ERROR: Could not determine upgrade path")
+                return 1
+            
+            target_version = upgrade_data['next_version']
+            
+            # Update log filename with version info
+            new_log_file = Path("logs") / f"{current_version}_to_{target_version}_{timestamp}.log"
+            if self.log_file and self.log_file.exists():
+                self.log_file.rename(new_log_file)
+                self.log_file = new_log_file
+            
+            # Step 5: Perform upgrade
+            if not self.perform_upgrade(target_version):
+                self._log("ERROR: Upgrade failed")
+                return 1
+            
+            # Step 6: Verify upgrade
+            if not self.verify_upgrade():
+                self._log("WARNING: Post-upgrade validation had issues")
+                self._log("Please investigate manually before proceeding")
+                return 1
+            
+            # Success - clear status file
+            self._reset_status()
+            
+            self._log("" + "="*60)
+            self._log("✓ UPGRADE COMPLETE")
+            self._log(f"  From: {current_version}")
+            self._log(f"  To:   {target_version}")
+            self._log(f"  Log:  {self.log_file}")
+            self._log("="*60)
+            
+            return 0
+            
+        except KeyboardInterrupt:
+            self._log("\nUpgrade interrupted by user (Ctrl+C)")
+            return 130
+        except Exception as e:
+            self._log(f"\n\nFATAL ERROR: {e}")
+            import traceback
+            self._log(traceback.format_exc())
+            return 1
+        finally:
+            self.cleanup()
+
+
+def main():
+    """Main entry point."""
+    upgrader = GitLabUpgrader()
+    
+    # Set AWS profile from config
+    os.environ['AWS_PROFILE'] = upgrader.config['aws_profile']
+    
+    exit_code = upgrader.run()
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Add GitLab upgrade tooling (`scripts/gitlab-upgrade/`)

Introduces a set of Python/cmd scripts to manage GitLab EE upgrades on the
production EC2 instance with safety checks, diagnostics, and service management.

### What's included

- **`upgrade.py` / `setup_and_run.cmd`** — Automated upgrade orchestrator.
  Verifies S3 backups, detects the current version, queries the GitLab upgrade
  path API for the correct next version stop, performs the upgrade via SSH
  (`yum install` + `gitlab-ctl reconfigure`), and validates post-upgrade service
  health. Supports resume-on-failure via `status.json`.

- **`trouble-shoot.py`** — Read-only diagnostic collector. SSHs into the
  instance and captures service status, system resources, port bindings, health
  endpoints, DB migration state, key log files, yum history, SELinux/firewall
  state, and S3 backup info. Writes a timestamped log to `logs/` for offline
  analysis.

- **`status-gitlab.py`** — Service status checker and manager. Supports
  `--start`, `--restart`, `--reconfigure`, `--tail`, and `--watch` flags to
  monitor and recover services after an upgrade. Logs to `logs/` with a
  timestamp.

- **`config.json`** — Instance config (IP, SSH key path, AWS profile, S3
  bucket).

- **`requirements.txt`** — `boto3`, `paramiko`, `requests`, `packaging`.
